### PR TITLE
Modified the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ translation is based. This is to keep track of the updates.
 original version, so a different commit reference does not automatically mean
 an outdated translation).
 
-* [Spanish][lng_es] by [Axel Pardemann][lng_es_author] from commit [34dcc91][lng_es_commit] maintained in [axelitus/developers-manifesto][lng_es_repo].
+* [Spanish][lng_es] by [Axel Pardemann][lng_es_author] from commit [34dcc91][lng_es_commit] maintained in [axelitus/developers-manifesto/feature/translation-spanish][lng_es_repo_branch].
 
 
 
@@ -45,4 +45,4 @@ an outdated translation).
 [lng_es]: es/manifesto.md
 [lng_es_commit]: https://github.com/digital-guerrilla/developers-manifesto/tree/34dcc91e8be247bca2dbe6c1a2b62d20fc74677d
 [lng_es_author]: https://github.com/axelitus
-[lng_es_repo]: https://github.com/axelitus/developers-manifesto
+[lng_es_repo_branch]: https://github.com/axelitus/developers-manifesto/tree/feature/translation-spanish

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The `url` and `image` fields are optional. See the instructions in the file for 
 
 ## Translations
 
-The manifesto is originally written in [English](en/manifesto.md "English").
+The manifesto is originally written in [English][lng_en].
 
 The following are translations made from the original Developer's Manifesto.
 
 The translations may not be updated to the latest changes of the original
-(English) version so a commit reference from where the translation was made is
-included per translation. The translations should always reference the
+(English) version so a commit reference (of the tree) from where the translation
+was made is included per translation. The translations should always reference the
 original version; if a translation is made from another translated version,
 then include the same commit reference as the translated version from where the
 translation is based. This is to keep track of the updates.
@@ -33,7 +33,7 @@ translation is based. This is to keep track of the updates.
 original version, so a different commit reference does not automatically mean
 an outdated translation).
 
-* [Spanish](es/manifesto.md "Spanish") by [Axel Pardemann][lng_es_author] from commit [cda09ee][lng_es_commit].
+* [Spanish][lng_es] by [Axel Pardemann][lng_es_author] from commit [34dcc91][lng_es_commit] maintained in [axelitus/developers-manifesto][lng_es_repo].
 
 
 
@@ -43,5 +43,6 @@ an outdated translation).
 [lng_en]: en/manifesto.md
 
 [lng_es]: es/manifesto.md
-[lng_es_commit]: https://github.com/digital-guerrilla/developers-manifesto/commit/cda09eeaa3697b09e7e7f5c9ed7c9e5b84e01342
+[lng_es_commit]: https://github.com/digital-guerrilla/developers-manifesto/tree/34dcc91e8be247bca2dbe6c1a2b62d20fc74677d
 [lng_es_author]: https://github.com/axelitus
+[lng_es_repo]: https://github.com/axelitus/developers-manifesto

--- a/signed.yml
+++ b/signed.yml
@@ -31,3 +31,7 @@
   name: "Simon Emms"
   url: "http://simonemms.com"
   image: "https://en.gravatar.com/userimage/19326460/f13c9cbc09b375681ee80af8e2d5fb21.jpg"
+-
+  name: "Axel Pardemann"
+  url: "http://axelitus.mx"
+  image: "https://s.gravatar.com/avatar/d068835eabd66ac00a44feaec7bee262?s=50"


### PR DESCRIPTION
I've made some small modifications to the README file to be more precise.
- Now all of the links are working correctly (was previously using the image link markdown).
- Added the feature branch where the translation is maintained.
- Changed the commit reference and point to the tree at that commit and not directly to the commit.
- Signed the manifesto :)
